### PR TITLE
Consumer only stations

### DIFF
--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -29,3 +29,4 @@ max-train-length = Maximum Train Length
 stop-priority = Provider Priority
 ltn-depot = Stop is Depot (Boolean)
 ltn-no-min-delivery-size = Ignore Minimum Delivery Size
+ltn-only-consume = Only consume, do not provide

--- a/prototypes/signals.lua
+++ b/prototypes/signals.lua
@@ -47,5 +47,13 @@ data:extend({
     icon = "__"..MOD_NAME.."__/graphics/icons/no-min-shipment-size.png",
     subgroup = "LTN-signal",
     order = "z[LTN-signal]-ae[ltn-depot]"
+  },
+  {
+    type = "virtual-signal",
+    name = "ltn-only-consume",
+    icon = "__"..MOD_NAME.."__/graphics/icons/depot.png",
+    subgroup = "LTN-signal",
+    order = "z[LTN-signal]-ae[ltn-depot]"
   }
+
 })


### PR DESCRIPTION
  - configure a station to only request items, never offer them, even if
  the station has more items than configured by the constant combinator

* consumer only stations are indicated by a cyan lamp instead of green
* they are simply ignored when other stations search for provider stations
* there is a signal to configure a station as consumer only
* the signal has to be added to the constant combinator that configures the station
* the signal works pretty much like the depot signal and can be found close to it in the signal list as well
* the signal needs an own icon, I was too ~~lazy~~ untalented to create one myself.