### PR TITLE
1.2.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 1.2.2
 - overloading trains updates delivery size once per update interval (before update was only done once train leaves provider)
 - fixed overloading trains reserved too much of an item/fluid in provider
+- fixed fluid deliveries where accidentally deleted at departure from provider
 
 1.2.1
 - updated mod setting descriptions

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+1.2.2
+- overloading trains updates delivery size once per update interval (before update was only done once train leaves provider)
+- fixed overloading trains reserved too much of an item/fluid in provider
+
 1.2.1
 - updated mod setting descriptions
 - replaced floating-text hack to get inventory sizes with 0.15 functions

--- a/info.json
+++ b/info.json
@@ -1,11 +1,11 @@
 {
   "name": "LogisticTrainNetwork",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "title": "Logistic Train Network",
   "author": "Optera",
   "contact": "https://forums.factorio.com/memberlist.php?mode=viewprofile&u=21729",
   "homepage": "https://forums.factorio.com/viewtopic.php?f=94&t=36976",
   "description": "Adds new train stops forming a highly configurable logistic network.",
   "factorio_version": "0.15",
-	"dependencies": ["base >= 0.15.5", "?creative-mode >= 0.3.1"]
+	"dependencies": ["base >= 0.15.9", "?creative-mode >= 0.3.2"]
 }

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -11,7 +11,7 @@ ltn-dispatcher-finish-loading=finish loading
 
 
 [mod-setting-description]
-ltn-interface-log-level=Detail level of messages.\n 0: off - No messages will be generated.\n 1 errors only - Print only errors and warnings.\n 2: notifications - (default) Prints basic information like missing resources or generating deliveries.\n 3: expanded scheduler messages - Print detailed information about finding providers and trains.\n 4: debug - (use with logging output = logfile)\nGenerate detailed logfile for troubleshooting.
+ltn-interface-log-level=Detail level of messages.\n 0: off - No messages will be generated.\n 1: errors only - Print only errors and warnings.\n 2: notifications - (default) Prints basic information like missing resources or generating deliveries.\n 3: expanded scheduler messages - Print detailed information about finding providers and trains.\n 4: debug - (use with logging output = logfile)\nGenerate detailed logfile for troubleshooting.
 ltn-interface-log-output=Set message output.\n console: in game console\n log: logfile in factorio root directory\n console & logfile (default)
 ltn-interface-message-filter-age=Message age in ticks before filtered messages are shown again.\ndefault = 18000
 


### PR DESCRIPTION
- overloading trains updates delivery size once per update interval (before update was only done once train leaves provider)
- fixed overloading trains reserved too much of an item/fluid in provider
- fixed fluid deliveries where accidentally deleted at departure from provider